### PR TITLE
forgot to run

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
         run: npm install
         working-directory: ${{ env.WORK_PATH }}
       - name: Build site
-        run: npm build
+        run: npm run build
         working-directory: ${{ env.WORK_PATH }}
       - name: Deploy over SSH
         uses: easingthemes/ssh-deploy@v2.2.11


### PR DESCRIPTION
Missed `run` in #437 causes post-PR deploy to fail. 