### PR TITLE
Tag template

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -5,6 +5,7 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addLayoutAlias("home", "layouts/home.html");
   eleventyConfig.addLayoutAlias("page", "layouts/page.html");
   eleventyConfig.addLayoutAlias("post", "layouts/post.html");
+  eleventyConfig.addLayoutAlias("tag", "layouts/tag.html");
 
   eleventyConfig.addPassthroughCopy("fonts");
   eleventyConfig.addPassthroughCopy("img");

--- a/_includes/layouts/tag.html
+++ b/_includes/layouts/tag.html
@@ -1,0 +1,9 @@
+---
+---
+{% include "header.html" %}
+{% include "page-header.html" %}
+<main class="post" id="content">
+  {{ content }}
+</main>
+{% include "page-footer.html" %}
+{% include "footer.html" %}

--- a/posts/spoke-clip.md
+++ b/posts/spoke-clip.md
@@ -1,5 +1,5 @@
 ---
-title: Fork Seal Clip for a 1982 Suzuki GS850L Motorcycle
+title: Fork Seal Clip for a 1982 Suzuki GS850L
 date: 2014-09-24T12:00:00Z
 layout: post
 tags:

--- a/tags.njk
+++ b/tags.njk
@@ -6,7 +6,7 @@ pagination:
     - all
     - post
   alias: tag
-layout: page
+layout: tag
 permalink: /{{ tag }}/
 ---
 <h1>Posts tagged with {{ tag }}</h1>


### PR DESCRIPTION
Ran a site scan using the very impressive [Evaluatory](https://darekkay.com/evaluatory/) tool that [Darek Kay](https://github.com/darekkay) built.

- Adds a tag template to avoid double (and empty) `<h1>`
- Reducing title length a bit on one post