### PR TITLE
Accessibility scan action

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -3,6 +3,9 @@ name: Build and test
 on:
   workflow_dispatch: # enable run button on github.com
   pull_request:
+  push:
+    branches:
+      - accessibility-scan-action
   schedule:
     - cron: "03 00 * * 4" # Run every Thursday at 12:03am
 
@@ -23,16 +26,30 @@ jobs:
         run: npm install
       - name: Build site and test
         run: npm test
-      - name: Run Lighthouse on local build
-        uses: treosh/lighthouse-ci-action@v9
+      - name: Serve site for scanning
+        run: npm run write
+      - name: Scan site
+        uses: double-great/accessibility-scan-action@v0.1.0
         with:
-          configPath: "./lighthouserc.json"
-      - name: Run Accessibility Insights site-wide
-        uses: microsoft/accessibility-insights-action@v3
-        with:
-          static-site-dir: ${{ github.workspace }}/_site
-      - name: Upload Accessibility Insights report as artifact
+          url: "https://www.washington.edu/accesscomputing/AU/before.html"
+          # baselineFile: ${{ github.workspace }}/samples/site.baseline
+
+      - name: Upload report as artifact
         uses: actions/upload-artifact@v3
+        if: success() || failure()
         with:
-          name: accessibility-reports
-          path: ${{ github.workspace }}/_accessibility-reports
+          name: "Accessibility report"
+          path: ${{ github.workspace }}/_accessibility-reports/
+      # - name: Run Lighthouse on local build
+      #   uses: treosh/lighthouse-ci-action@v9
+      #   with:
+      #     configPath: "./lighthouserc.json"
+      # - name: Run Accessibility Insights site-wide
+      #   uses: microsoft/accessibility-insights-action@v3
+      #   with:
+      #     static-site-dir: ${{ github.workspace }}/_site
+      # - name: Upload Accessibility Insights report as artifact
+      #   uses: actions/upload-artifact@v3
+      #   with:
+      #     name: accessibility-reports
+      #     path: ${{ github.workspace }}/_accessibility-reports

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,18 +19,21 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "lts/*"
+          node-version: "16"
           cache: "npm"
           cache-dependency-path: "./package-lock.json"
       - name: Install dependencies
         run: npm install
       - name: Build site and test
         run: npm test
+
+      - run: npm run write &
+
       - name: Scan site
         uses: double-great/accessibility-scan-action@v0.1.0
         with:
-          url: "https://www.washington.edu/accesscomputing/AU/before.html"
-          # baselineFile: ${{ github.workspace }}/samples/site.baseline
+          url: "http://localhost:8080"
+          # baselineFile: ${{ github.workspace }}/baseline/site.baseline
 
       - name: Upload report as artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -33,7 +33,6 @@ jobs:
         uses: double-great/accessibility-scan-action@v0.1.0
         with:
           url: "http://localhost:8080"
-          # baselineFile: ${{ github.workspace }}/baseline/site.baseline
 
       - name: Upload report as artifact
         uses: actions/upload-artifact@v3
@@ -41,16 +40,3 @@ jobs:
         with:
           name: "Accessibility report"
           path: ${{ github.workspace }}/_accessibility-reports/
-      # - name: Run Lighthouse on local build
-      #   uses: treosh/lighthouse-ci-action@v9
-      #   with:
-      #     configPath: "./lighthouserc.json"
-      # - name: Run Accessibility Insights site-wide
-      #   uses: microsoft/accessibility-insights-action@v3
-      #   with:
-      #     static-site-dir: ${{ github.workspace }}/_site
-      # - name: Upload Accessibility Insights report as artifact
-      #   uses: actions/upload-artifact@v3
-      #   with:
-      #     name: accessibility-reports
-      #     path: ${{ github.workspace }}/_accessibility-reports

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -26,8 +26,6 @@ jobs:
         run: npm install
       - name: Build site and test
         run: npm test
-      - name: Serve site for scanning
-        run: npm run write
       - name: Scan site
         uses: double-great/accessibility-scan-action@v0.1.0
         with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -3,9 +3,6 @@ name: Build and test
 on:
   workflow_dispatch: # enable run button on github.com
   pull_request:
-  push:
-    branches:
-      - accessibility-scan-action
   schedule:
     - cron: "03 00 * * 4" # Run every Thursday at 12:03am
 


### PR DESCRIPTION
Switch to using https://github.com/double-great/accessibility-scan-action to run Accessibility Insights for Web via the CLI across all site pages, on every PR.

This also removes the Lighthouse report and Accessibility Insights action steps.