### PR TITLE
Don't add `<figcaption>` if there isn't a caption

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -133,7 +133,9 @@ module.exports = function (eleventyConfig) {
         });
       })();
 
-      return `<figure><picture>${sourcesAvif}${sourcesWebp}${sourcesVintage}<img src="${fullPath}-240.${ext}" alt="${alt}" loading="lazy" width="${width}" height="${height}"></picture><figcaption>${caption}</figcaption></figure>`;
+      return `<figure><picture>${sourcesAvif}${sourcesWebp}${sourcesVintage}<img src="${fullPath}-240.${ext}" alt="${alt}" loading="lazy" width="${width}" height="${height}"></picture>${
+        caption ? `<figcaption>${caption}</figcaption>` : ""
+      }</figure>`;
     },
   );
   // Usage: {% picture "file-name", "jpg", "240", "159", "1600" "Alt text.", "Caption" %}


### PR DESCRIPTION
Spotted using the Stark extension