### PR TITLE
Add `tabindex="-1"` back to skip link target

### DIFF
--- a/_includes/layouts/doc.html
+++ b/_includes/layouts/doc.html
@@ -1,7 +1,7 @@
 ---
 ---
 {% include "header.html" %}
-<main id="content">
+<main id="content" tabindex="-1">
   <div class="doc">
     <h1>{{ title }}</h1>
     {{ content }}

--- a/_includes/layouts/home.html
+++ b/_includes/layouts/home.html
@@ -1,7 +1,7 @@
 ---
 ---
 {% include "header.html" %}
-<main class="home">
+<main class="home" tabindex="-1">
   <h1>{{ title }}</h1>
   <nav>
     <ul class="chunk bump">

--- a/_includes/layouts/page.html
+++ b/_includes/layouts/page.html
@@ -2,7 +2,7 @@
 ---
 {% include "header.html" %}
 {% include "page-header.html" %}
-<main class="post" id="content">
+<main class="post" id="content" tabindex="-1">
   <h1>{{ title }}</h1>
   {{ content }}
 </main>

--- a/_includes/layouts/tag.html
+++ b/_includes/layouts/tag.html
@@ -2,7 +2,7 @@
 ---
 {% include "header.html" %}
 {% include "page-header.html" %}
-<main class="post" id="content">
+<main class="post" id="content" tabindex="-1">
   {{ content }}
 </main>
 {% include "page-footer.html" %}


### PR DESCRIPTION
Avoid loss of keyboard focus (moves to `<body>`) when using the skip to content link.

Reverts https://github.com/jsnmrs/jasonmorris/commit/63a012435d9ebb25bba11f7aa5b590322ba243ea