### PR TITLE
Replace static node version with LTS

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "16"
+          node-version: "lts/*"
           cache: "npm"
           cache-dependency-path: "./package-lock.json"
       - name: Install dependencies


### PR DESCRIPTION
I missed this one until the build on #700 failed