### PR TITLE
Update crossorigin attribute

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,8 +7,8 @@
   <meta name="author" content="{{ site.name }}">{% if meta %}
   <meta name="description" content="{{ meta }}">{% endif %}
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="preload" href="/fonts/atkinson-hyperlegible.woff2" as="font" type="font/woff2" crossorigin>{% if has contains "code" %}
-  <link rel="preload" href="/fonts/scp.woff2" as="font" type="font/woff2" crossorigin>{% endif %}
+  <link rel="preload" href="/fonts/atkinson-hyperlegible.woff2" as="font" type="font/woff2" crossorigin="anonymous">{% if has contains "code" %}
+  <link rel="preload" href="/fonts/scp.woff2" as="font" type="font/woff2" crossorigin="anonymous">{% endif %}
   <meta name="theme-color" content="#727272">
   <link rel="icon" href="/favicon.ico" sizes="any">
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">


### PR DESCRIPTION
via https://htmhell.dev/adventcalendar/2024/25/
>For fonts you almost always want crossorigin="anonymous" on your link element, even when the request isn’t cross-origin. Omitting this attribute would mean our preload wouldn’t be used and the file would be requested again. But why?
>
>Browser requests can be sent either with or without credentials (cookies, etc), and requests to the same URL with and without credentials are fundamentally different. For a preload to be used by the browser, it needs to match the type of request that the browser would have made normally. By default fonts are always requested without credentials, so we need to add crossorigin="anonymous" to ensure our preload matches a normal font request.
>
>By omitting this attribute our preload would not be used and the browser would request the font again. If you’re ever unsure of how your preloads are working, check your browsers’ devtools. In Chrome the Network pane will show a duplicate request, and the Console will log a warning telling you a preload wasn’t used.