### PR TITLE
Add llms.txt

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -135,4 +135,7 @@ AddDefaultCharset utf-8
 
   # HTML
   ExpiresByType text/html "access plus 0 seconds"
+
+  # Plain text (llms.txt, robots.txt)
+  ExpiresByType text/plain "access plus 0 seconds"
 </IfModule>

--- a/_data/site.json
+++ b/_data/site.json
@@ -1,5 +1,6 @@
 {
   "name": "Jason Morris",
   "url": "https://jasonmorris.com",
+  "description": "The personal website of Jason Morris, an accessibility engineer and front-end developer in upstate New York.",
   "timezone": "America/New_York"
 }

--- a/llms.njk
+++ b/llms.njk
@@ -1,0 +1,31 @@
+---
+permalink: /llms.txt
+eleventyExcludeFromCollections: true
+---
+# {{ site.name }}
+
+> {{ site.description }}
+
+All URLs below serve HTML; this site does not publish markdown versions of its
+pages. Markdown source for every post and page lives in the GitHub repository
+linked under Optional. Posts are grouped into four categories (bikes, code, diy,
+photo) and each post URL follows the pattern /<category>/<slug>/.
+
+## About
+
+- [Home]({{ site.url }}/): Short bio and a reverse-chronological index of every post.
+- [Resume]({{ site.url }}/resume/): Work history, certifications, and skills. Over 20 years building and validating accessible web experiences, largely for US federal government health agencies.
+- [Uses]({{ site.url }}/uses/): The hardware, software, and workspace defaults Jason works with.
+- [Accessibility statement]({{ site.url }}/accessibility/): This site's WCAG 2.2 AA conformance claim, how it is tested, and how to report a barrier.
+
+## Posts
+{% for post in collections.post | reverse %}
+- [{{ post.data.title }}]({{ site.url }}{{ post.url }}): {{ post.data.meta | trim }}
+{%- endfor %}
+
+## Optional
+
+- [Atom feed]({{ site.url }}/atom.xml): Full-content feed of all posts.
+- [Sitemap]({{ site.url }}/sitemap.xml): Complete list of indexable URLs.
+- [Resume as tagged PDF]({{ site.url }}/jason-morris-resume.pdf): Accessible tagged PDF of the resume page.
+- [Source repository](https://github.com/jsnmrs/jasonmorris): Eleventy source for this site, including the original markdown for every post and page.


### PR DESCRIPTION
Publishes a curated `/llms.txt` following the [llmstxt.org](https://llmstxt.org/) spec (currently v2), giving LLM agents an entry point into the site.

`sitemap.xml` does not serve this purpose: it lists every URL flatly with no descriptions, cannot reference anything off-site, and in aggregate exceeds a context window. `llms.txt` is the inverse — a small curated index an agent reads first and follows links from. The spec explicitly names this use case, "a personal site answering questions about someone's CV."

## Changes

**`llms.njk`** renders `/llms.txt`. It follows the same root-template pattern as `sitemap.njk` and `atom.njk`, so no `.eleventy.js` change was needed — a literal `llms.txt` would have had to be added to the `STATIC_ASSETS` passthrough array instead, since `.txt` is not a template format Eleventy processes.

Posts are generated from `collections.post`, with each description reusing the file's existing `meta:` front matter, so the file stays current as posts are published. The About and Optional sections are hand-curated.

**`_data/site.json`** gains a `description` key. Note this also changes feed output: `atom.njk` already referenced `{{ site.description }}` and has been rendering an empty `<subtitle></subtitle>`. This fills it in.

**`.htaccess`** gains `ExpiresByType text/plain "access plus 0 seconds"`. This fixes a latent bug rather than just supporting the new file — `ExpiresDefault "access plus 1 year"` had no `text/plain` override, so `robots.txt` has been served with a one-year cache all along, and `/llms.txt` would have inherited it.

## Verification

- `npm run build` (lint, build, validate) exits 0
- All 12 posts render newest-first with descriptions
- Structure matches spec order: H1, blockquote, non-heading prose, H2 link sections. No H3+
- `/llms.txt` stays out of `sitemap.xml` via `eleventyExcludeFromCollections`
- All 20 links return 200 against a local serve

## Not included

Per the spec, links should ideally point at markdown versions of pages, exposed via `rel="alternate" type="text/markdown"`. The site publishes none, and roughly half its content is authored in HTML rather than markdown, so this is not a straight passthrough. The prose block in `llms.txt` states this plainly and points agents at the GitHub source instead. Worth revisiting separately.

Also skipped: `/llms-full.txt` (not part of the spec — a Mintlify convention), and `/readme/`, whose body is currently just "In progress."

## Related

Two inconsistencies surfaced while writing this and are tracked separately, not fixed here: #928 (stylelint drift on every build) and #929 (AA vs AAA conformance target, which matters more now that `llms.txt` points agents at `/accessibility/` as the authoritative answer).